### PR TITLE
Deploy to Zendesk on master push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+env:
+  ZENDESK_USERNAME: ${{ secrets.ZENDESK_USERNAME }}
+  ZENDESK_PASSWORD: ${{ secrets.ZENDESK_PASSWORD }}
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm ci
+    - name: Create zatfile
+      run: |
+        cp .zat.example .zat
+        sed -i -e "s|USERNAME_GOES_HERE|$ZENDESK_USERNAME|g" .zat
+        sed -i -e "s|PASSWORD_GOES_HERE|$ZENDESK_PASSWORD|g" .zat
+    - name: Build and push to Zendesk
+      run: ./script/build --push

--- a/README.md
+++ b/README.md
@@ -62,21 +62,22 @@ Run the following command:
 ./script/test
 ```
 
-## Building a new version
+## Building and updating the app
 
-Run the following command:
+The repo is set up to automatically push to Zendesk on every `master` push, but in case you want to
+do this manaually, you can run:
 
 ```
 ./script/build
 ```
 
-This builds the Javascript using [Webpack](https://webpack.js.org/), and generates a zip file of the
+to build the app in the `/dist` folder using [Webpack](https://webpack.js.org/), and generate a zip file of the
 project in `dist/tmp`.
 
-## Updating the app
-
-Run the following command:
+To update the app in Zendesk, run:
 
 ```
 ./script/build --push
 ```
+
+This assumes you have the correct credentials in your `.zat` file.


### PR DESCRIPTION
This creates a `.zat` file with the correct credentials, and then builds and deploys to app to Zendesk.