### PR TITLE
Add DNS Management field to sidebar

### DIFF
--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -62,6 +62,7 @@ describe('Example App', () => {
       expect(document.querySelector('#project_wisdom .maintenance_status').textContent).toMatch(project.maintenance_status)
       expect(document.querySelector('#project_wisdom .hosting_location').textContent).toMatch(project.hosting_location)
       expect(document.querySelector('#project_wisdom .developer_names').textContent).toMatch(project.developer_names)
+      expect(document.querySelector('#project_wisdom .dns_management').textContent).toMatch(project.dns_management)
 
       expect(document.querySelector('#project_wisdom .git_repository_0').innerHTML).toMatch('GitHub repository')
       expect(document.querySelector('#project_wisdom .git_repository_0').innerHTML).toMatch(project.git_repositories[0]['URL'])

--- a/spec/fixtures/my-project.json
+++ b/spec/fixtures/my-project.json
@@ -12,7 +12,8 @@
       "Trello Board": "http://trello.com/1234",
       "Google Drive Folder": "http://drive.google.com/1234",
       "Git Repositories": ["123", "456"],
-      "Slack Channels": ["123", "456"]
+      "Slack Channels": ["123", "456"],
+      "DNS Management": "Wayne Enterprises"
     }
   }
 ]

--- a/spec/project.spec.js
+++ b/spec/project.spec.js
@@ -28,6 +28,10 @@ describe('project.js', async () => {
     expect(project.developer_names).toEqual('The Joker, The Riddler')
   })
 
+  it('returns DNS management information', () => {
+    expect(project.dns_management).toEqual('Wayne Enterprises')
+  })
+
   it('returns git repositories', () => {
     expect(project.git_repositories).toEqual([
       {

--- a/src/javascripts/lib/project.js
+++ b/src/javascripts/lib/project.js
@@ -34,6 +34,7 @@ class Project {
     this.slack_url = this._fields['Slack Link']
     this.trello_url = this._fields['Trello Board']
     this.drive_url = this._fields['Google Drive Folder']
+    this.dns_management = this._fields['DNS Management']
   }
 
   airtableURL () {

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -59,6 +59,12 @@ export default function (args) {
         {{ project.developer_names }}
       </li>
     {{/if}}
+    {{#if project.dns_management}}
+      <li class="dns_management">
+        <strong>DNS Management</strong><br>
+        {{ project.dns_management }}
+      </li>
+    {{/if}}
     </ul>
 
     <div class="links u-mv-sm u-pv-sm u-border-t">


### PR DESCRIPTION
Adds additional data on where DNS for any particular project is managed, and who by.