### PR TITLE
Add support for Support Runbook link

### DIFF
--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -56,6 +56,7 @@ describe('Example App', () => {
     it('should display the project data', () => {
       expect(document.querySelector('#project_wisdom')).not.toBe(null)
       expect(document.querySelector('#project_wisdom h2').textContent).toBe(project.project_name)
+      expect(document.querySelector('#project_wisdom .runbook_url').innerHTML).toMatch(project.runbook_url)
       expect(document.querySelector('#project_wisdom .wisdom_url').innerHTML).toMatch(project.wisdom_url)
 
       expect(document.querySelector('#project_wisdom .client').textContent).toMatch(project.clients)

--- a/spec/fixtures/my-project.json
+++ b/spec/fixtures/my-project.json
@@ -8,6 +8,7 @@
       "Client": ["123"],
       "Hosted On": ["567"],
       "Developers": ["123", "456"],
+      "Support Runbook": "http://example.com/runbook",
       "Project Wisdom": "http://example.com",
       "Trello Board": "http://trello.com/1234",
       "Google Drive Folder": "http://drive.google.com/1234",

--- a/src/javascripts/lib/project.js
+++ b/src/javascripts/lib/project.js
@@ -28,6 +28,7 @@ class Project {
     this.developer_names = await this._developerNames()
     this.git_repositories = await this._gitRepositories()
     this.slack_channels = await this._slackChannels()
+    this.runbook_url = this._fields['Support Runbook']
     this.wisdom_url = this._fields['Project Wisdom']
     this.production_url = this._fields['Production URL']
     this.staging_url = this._fields['Staging URL']

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -17,9 +17,14 @@ export default function (args) {
     <h2 class="u-semibold u-fs-lg">{{ project.project_name }}</h2>
 
     <ul class="u-mv-sm">
+      {{#if project.runbook_url}}
+      <li class="runbook_url">
+        <strong><i class="fas fa-fw fa-book"></i> <a href="{{project.runbook_url}}" target="_blank">Support Runbook</a></strong>
+      </li>
+      {{/if}}
       {{#if project.wisdom_url}}
       <li class="wisdom_url">
-        <strong><i class="fas fa-fw fa-brain"></i> <a href="{{project.wisdom_url}}" target="_blank">Read the Project Wisdom</a></strong>
+        <strong><i class="fas fa-fw fa-brain"></i> <a href="{{project.wisdom_url}}" target="_blank">Project Wisdom</a></strong>
       </li>
       {{/if}}
       {{#if project.production_url}}


### PR DESCRIPTION
Where Project Wisdom offers history on the project and its rationale, the Support Runbook is a more practical set of instructions to handle common support procedures.