### PR TITLE
Assorted tooling improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,18 +17,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby
       uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6.x
-    - name: Install Zendesk Apps Tooks
-      run: gem install zendesk_apps_tools
-    - name: Install Node dependencies
-      run: npm ci
+    - name: Install dependencies
+      run: script/bootstrap
     - name: Create zatfile
       run: |
         cp .zat.example .zat
         sed -i -e "s|USERNAME_GOES_HERE|$ZENDESK_USERNAME|g" .zat
         sed -i -e "s|PASSWORD_GOES_HERE|$ZENDESK_PASSWORD|g" .zat
     - name: Build and push to Zendesk
-      run: ./script/build --push
+      run: script/build --push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
     - name: Install dependencies
-      run: npm ci
+      run: script/bootstrap
     - name: Run tests
-      run: ./script/test
+      run: script/test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "foreman", "~> 0.87.1"
+
+gem "zendesk_apps_tools", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,105 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    concurrent-ruby (1.1.6)
+    crass (1.0.6)
+    daemons (1.3.1)
+    erubis (2.7.0)
+    eventmachine (1.2.7)
+    execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faye-websocket (0.10.9)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
+    ffi (1.9.25)
+    foreman (0.87.1)
+    hitimes (2.0.0)
+    i18n (1.8.3)
+      concurrent-ruby (~> 1.0)
+    image_size (2.0.2)
+    ipaddress_2 (0.13.0)
+    json (2.3.1)
+    listen (2.10.1)
+      celluloid (~> 0.16.0)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mimemagic (0.3.5)
+    mini_portile2 (2.3.0)
+    multipart-post (2.1.1)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    rack (1.6.13)
+    rack-livereload (0.3.17)
+      rack
+    rack-protection (1.5.5)
+      rack
+    rb-fsevent (0.10.4)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rubyzip (1.2.4)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (1.11.4)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-cross_origin (0.3.2)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    thor (0.19.4)
+    tilt (2.0.10)
+    timers (4.0.4)
+      hitimes
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zendesk_apps_support (4.29.2)
+      erubis
+      i18n
+      image_size
+      ipaddress_2 (~> 0.13.0)
+      json
+      loofah (~> 2.2.3)
+      mimemagic (~> 0.3.3)
+      nokogiri (~> 1.8.5)
+      rb-inotify (= 0.9.10)
+      sass
+      sassc (~> 1.11.2)
+    zendesk_apps_tools (3.8.0)
+      execjs (~> 2.7.0)
+      faraday (~> 0.9.2)
+      faye-websocket (~> 0.10.7)
+      listen (~> 2.10)
+      rack-livereload
+      rubyzip (~> 1.2.1)
+      sinatra (~> 1.4.6)
+      sinatra-cross_origin (~> 0.3.1)
+      thin (~> 1.7.2)
+      thor (~> 0.19.4)
+      zendesk_apps_support (~> 4.29.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  foreman (~> 0.87.1)
+  zendesk_apps_support (~> 4.29)
+  zendesk_apps_tools (~> 3.8)
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To run the app locally, you'll need to have the following installed:
 git clone git@github.com:dxw/project_wisdom.git
 ```
 
-### Copy .zat.example to .zat
+### Run the setup task
 
 ```bash
-cp .zat.example .zat
+./script/setup
 ```
 
 ### Add the username and password to the .zat file (optional)
@@ -33,16 +33,10 @@ Necessary if you want to run the server, but not if all you want is to run the t
 Where "username" is your Zendesk login with `/token` appended to the end (e.g. `foo@dxw.com/token`), and "password" is
 available in the dxw 1Password as "Zendesk API Key".
 
-### Install dependencies
+## Running the server locally
 
 ```bash
-./script/bootstrap
-```
-
-### Run the server locally
-
-```bash
-./script/server
+script/server
 ```
 
 You'll need the Airtable API Key and Base Key (available from the dxw 1Password).
@@ -59,28 +53,28 @@ Click on the `Apps` button on the ticket view to see the app in action!
 
 ## Running the tests
 
-Run the following command:
+Run the following script:
 
 ```
-./script/test
+script/test
 ```
 
 ## Building and updating the app
 
-The repo is set up to automatically push to Zendesk on every `master` push, but in case you want to
-do this manually, you can run:
+To rebuild the app locally following changes, run
 
 ```
-./script/build
+script/build
 ```
 
 to build the app in the `/dist` folder using [Webpack](https://webpack.js.org/), and generate a zip file of the
 project in `dist/tmp`.
 
-To update the app in Zendesk, run:
+The repo is set up to automatically push to Zendesk on every `master` push, but in case you want to
+do this manually and push the updated package to Zendesk, you can run:
 
 ```
-./script/build --push
+script/build --push
 ```
 
 This assumes you have the correct credentials in your `.zat` file.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "project_wisdom",
   "version": "0.0.1",
   "description": "A Zendesk App that fetches contextual information about a ticket from its custom project field.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxw/project_wisdom"
+  },
   "keywords": [
     "zendesk",
     "app",
@@ -18,8 +22,7 @@
     "build:dev": "webpack --mode=development",
     "build": "webpack -p --mode=production",
     "lint": "standard",
-    "lint:fix": "standard --fix",
-    "start": "zat server -p ./dist --unattended"
+    "lint:fix": "standard --fix"
   },
   "devDependencies": {
     "@zendeskgarden/css-arrows": "^3.1.4",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-gem install zendesk_apps_tools foreman
-npm install
-npm run build
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing gem dependencies…"
+bundle check >/dev/null 2>&1  || {
+  bundle install --quiet
+}
+
+echo "==> Installing npm dependencies…"
+npm install --silent

--- a/script/build
+++ b/script/build
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+cd "$(dirname "$0")/.."
+
 while [ "$1" ]; do
   case $1 in
     "--push")
@@ -9,10 +13,14 @@ while [ "$1" ]; do
   shift
 done
 
+echo "==> Building package…"
+
 npm run build
 
 if [ "$PUSH_TO_ZENDESK" ]; then
-  zat update -p dist
+  echo "==> Packaging and pushing to Zendesk…"
+  bundle exec zat update -p dist
 else
-  zat package -p dist
+  echo "==> Packaging for local ZAT…"
+  bundle exec zat package -p dist
 fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+
+script/build
+
+echo "==> App is now ready to go!"

--- a/script/setup
+++ b/script/setup
@@ -6,6 +6,9 @@ cd "$(dirname "$0")/.."
 
 script/bootstrap
 
+echo "==> Copying .zat.example to .zat!"
+cp .zat.example .zat
+
 script/build
 
 echo "==> App is now ready to go!"

--- a/script/setup
+++ b/script/setup
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 
 script/bootstrap
 
-echo "==> Copying .zat.example to .zat!"
+echo "==> Copying .zat.example to .zat…"
 cp .zat.example .zat
 
 script/build

--- a/script/test
+++ b/script/test
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-npm run lint && npm test
+set -e
 
+cd "$(dirname "$0")/.."
+
+script/update
+
+echo "==> Running tests…"
+
+npm run lint && npm test

--- a/script/update
+++ b/script/update
@@ -4,6 +4,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-script/update
-
-bundle exec foreman start
+script/bootstrap


### PR DESCRIPTION
- Improves overall resiliency of build scripts
- Better follows Scripts To Rule Them All pattern
  - Adds `script/update`
  - Adds `script/setup`
- Gets ruby version requirements from `.ruby-version` instead of explicitly specifying in workflow files
- Removes some unused bits of npm configuration
- Adds a repository to the npm configuration to suppress warnings
- Handles gem requirements using bundler.
- `.zat.example` file is now automatically copied to `.zat` as part of setup.
- README updates and clarifications.