### PR TITLE
Display account manager in zendesk widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ script/build --push
 ```
 
 This assumes you have the correct credentials in your `.zat` file.
+
+### Adding new fields
+
+When adding new fields, these are the files you will need to look at:
+`default.js`, `project.js`
+
+For the relating spec changes:
+`app.spec.js`, `project.spec.js`
+
+`my-project.json` is the test data used within the spec files.

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -66,6 +66,7 @@ describe('Example App', () => {
       expect(projectWisdom.querySelector('.hosting_location').textContent).toMatch(project.hosting_location)
       expect(projectWisdom.querySelector('.developer_names').textContent).toMatch(project.developer_names)
       expect(projectWisdom.querySelector('.dns_management').textContent).toMatch(project.dns_management)
+      expect(projectWisdom.querySelector('.account_manager').textContent).toMatch(project.account_manager)
 
       expect(projectWisdom.querySelector('.url_0').innerHTML).toMatch(project.urls[0].Domain)
       expect(projectWisdom.querySelector('.url_0').innerHTML).toMatch('Staging')

--- a/spec/fixtures/my-project.json
+++ b/spec/fixtures/my-project.json
@@ -15,7 +15,8 @@
       "Git Repositories": ["123", "456"],
       "Slack Channels": ["123", "456"],
       "URLs": ["rec368HRI9tWxIgkk", "rec4aGLpEojsa4vdi"],
-      "DNS Management": "Wayne Enterprises"
+      "DNS Management": "Wayne Enterprises",
+      "Account Manager": "Sam Smith"
     }
   }
 ]

--- a/spec/project.spec.js
+++ b/spec/project.spec.js
@@ -32,6 +32,10 @@ describe('project.js', async () => {
     expect(project.dns_management).toEqual('Wayne Enterprises')
   })
 
+  it('returns account manager name', () => {
+    expect(project.account_manager).toEqual('Sam Smith')
+  })
+
   it('returns git repositories', () => {
     expect(project.git_repositories).toEqual([
       {

--- a/src/javascripts/lib/project.js
+++ b/src/javascripts/lib/project.js
@@ -37,6 +37,7 @@ class Project {
     this.trello_url = this._fields['Trello Board']
     this.drive_url = this._fields['Google Drive Folder']
     this.dns_management = this._fields['DNS Management']
+    this.account_manager = this._fields['Account Manager']
   }
 
   airtableURL () {

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -74,6 +74,12 @@ export default function (args) {
         {{ project.dns_management }}
       </li>
     {{/if}}
+    {{#if project.account_manager}}
+      <li class="account_manager">
+        <strong>Account Manager</strong><br>
+        {{ project.account_manager }}
+      </li>
+    {{/if}}
     </ul>
 
     <div class="links u-mv-sm u-pv-sm u-border-t">


### PR DESCRIPTION
 Display Account Manager in project information

Within the Zendesk widget, displaying this information will help provide
contact details for a specific project

