### PR TITLE
Show account manager’s name instead of ID

### DIFF
--- a/spec/fixtures/my-project.json
+++ b/spec/fixtures/my-project.json
@@ -16,7 +16,7 @@
       "Slack Channels": ["123", "456"],
       "URLs": ["rec368HRI9tWxIgkk", "rec4aGLpEojsa4vdi"],
       "DNS Management": "Wayne Enterprises",
-      "Account Manager": "Sam Smith"
+      "Account Manager": ["789"]
     }
   }
 ]

--- a/spec/project.spec.js
+++ b/spec/project.spec.js
@@ -33,7 +33,7 @@ describe('project.js', async () => {
   })
 
   it('returns account manager name', () => {
-    expect(project.account_manager).toEqual('Sam Smith')
+    expect(project.account_manager).toEqual('King Tut')
   })
 
   it('returns git repositories', () => {

--- a/src/javascripts/lib/project.js
+++ b/src/javascripts/lib/project.js
@@ -37,7 +37,7 @@ class Project {
     this.trello_url = this._fields['Trello Board']
     this.drive_url = this._fields['Google Drive Folder']
     this.dns_management = this._fields['DNS Management']
-    this.account_manager = this._fields['Account Manager']
+    this.account_manager = await this._accountManagerName()
   }
 
   airtableURL () {
@@ -80,6 +80,15 @@ class Project {
     return developers.map(function (developer) {
       return developer.fields.Name
     }).join(', ')
+  }
+
+  async _accountManagerName () {
+    var accountManager = await this._findObjectsByIDs(
+      this._base.people(),
+      this._fields['Account Manager']
+    )
+
+    return accountManager[0].fields.Name
   }
 
   async _gitRepositories () {


### PR DESCRIPTION
The account manager field is not a plain string, but a reference to a person record.

Retrieve the person and show their name.