### PR TITLE
Use the dxw fork at a specific tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "foreman", "~> 0.87"
 
-gem "zendesk_apps_tools", "~> 3.8"
+# Forked from "zendesk/zendesk_apps_tools" to fix security alerts
+gem "zendesk_apps_tools", github: "dxw/zendesk_apps_tools", tag: "v3.8.1-dxw2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,21 @@
+GIT
+  remote: https://github.com/dxw/zendesk_apps_tools
+  revision: b5af38abc0a69e781fd473452a4a97728b6ee005
+  tag: v3.8.1-dxw2
+  specs:
+    zendesk_apps_tools (3.8.1)
+      execjs (~> 2.7.0)
+      faraday (~> 0.9.2)
+      faye-websocket (~> 0.11.0)
+      listen (~> 2.10)
+      rack-livereload
+      rubyzip (~> 1.3.0)
+      sinatra (~> 2.1.0)
+      sinatra-cross_origin (~> 0.3.1)
+      thin (~> 1.7.2)
+      thor (~> 0.19.4)
+      zendesk_apps_support (~> 4.29.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -11,7 +29,7 @@ GEM
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faye-websocket (0.10.9)
+    faye-websocket (0.11.0)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.9.25)
@@ -32,17 +50,20 @@ GEM
     mimemagic (0.3.5)
     mini_portile2 (2.4.0)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    rack (1.6.13)
+    rack (2.2.3)
     rack-livereload (0.3.17)
       rack
-    rack-protection (1.5.5)
+    rack-protection (2.1.0)
       rack
     rb-fsevent (0.10.4)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rubyzip (1.2.4)
+    ruby2_keywords (0.0.2)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -52,10 +73,11 @@ GEM
       bundler
       ffi (~> 1.9.6)
       sass (>= 3.3.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     sinatra-cross_origin (0.3.2)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
@@ -80,25 +102,13 @@ GEM
       rb-inotify (= 0.9.10)
       sass
       sassc (~> 1.11.2)
-    zendesk_apps_tools (3.8.1)
-      execjs (~> 2.7.0)
-      faraday (~> 0.9.2)
-      faye-websocket (~> 0.10.7)
-      listen (~> 2.10)
-      rack-livereload
-      rubyzip (~> 1.2.1)
-      sinatra (~> 1.4.6)
-      sinatra-cross_origin (~> 0.3.1)
-      thin (~> 1.7.2)
-      thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.29.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   foreman (~> 0.87)
-  zendesk_apps_tools (~> 3.8)
+  zendesk_apps_tools!
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
The dxw fork fixes security alerts.

The upstream repo doesn’t have much activity, and doesn’t seem actively developed.